### PR TITLE
Fixed the McWEDA Harris-DOGS configure bullshit.

### DIFF
--- a/src/e.FDATA/M_Fdata_1c_McWEDA_DOGS.f90
+++ b/src/e.FDATA/M_Fdata_1c_McWEDA_DOGS.f90
@@ -1,10 +1,6 @@
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
-
 ! copyright info:
 !
-!                             @Copyright 2012
+!                             @Copyright 2010
 !                           Fireball Committee
 ! West Virginia University - James P. Lewis, Chair
 ! Arizona State University - Otto F. Sankey
@@ -43,7 +39,6 @@
 !
 ! ===========================================================================
 ! Code written by:
-!> @author Ning Ma
 !> @author James P. Lewis\n
 !! Box 6315, 209 Hodges Hall\n
 !! Department of Physics\n
@@ -122,13 +117,12 @@
 
 ! Variable Declaration and Description
 ! ===========================================================================
-        integer ispecies                          !< counter for number of species
-        integer nssh                              !< counters for number of shells
-        integer issh, jssh
-#ifdef DOGS
-        integer kssh
-#endif
-        character (len=32) filename
+        integer ispecies		          !< counter for number of species
+
+        integer nssh                      !< counters for number of shells
+        integer issh, jssh, kssh
+
+        character (len=30) filename
 
 ! Allocate Arrays
 ! ===========================================================================
@@ -161,7 +155,7 @@
         end do
         close (11)
 
-#ifdef DOGS
+
 ! ***************************************************************************
 !                       R E A D    P O T E N T I A L S
 ! ***************************************************************************
@@ -207,7 +201,6 @@
           end do
         end do
         close (11)
-#endif
 
 ! Deallocate Arrays
 ! ===========================================================================
@@ -265,11 +258,9 @@
 ! ===========================================================================
         do ispecies = 1, nspecies
           deallocate (vxc_1c(ispecies)%E)
-          deallocate (vxc_1c(ispecies)%V)
-#ifdef DOGS
           deallocate (vxc_1c(ispecies)%dE)
+          deallocate (vxc_1c(ispecies)%V)
           deallocate (vxc_1c(ispecies)%dV)
-#endif
         end do
 
 ! Deallocate Arrays

--- a/src/e.FDATA/M_Fdata_1c_McWEDA_Harris.f90
+++ b/src/e.FDATA/M_Fdata_1c_McWEDA_Harris.f90
@@ -1,0 +1,232 @@
+! copyright info:
+!
+!                             @Copyright 2012
+!                           Fireball Committee
+! West Virginia University - James P. Lewis, Chair
+! Arizona State University - Otto F. Sankey
+! Universidad Autonoma de Madrid - Jose Ortega
+! Academy of Sciences of the Czech Republic - Pavel Jelinek
+
+! Previous and/or current contributors:
+! Auburn University - Jian Jun Dong
+! Caltech - Brandon Keith
+! Dublin Institute of Technology - Barry Haycock
+! Pacific Northwest National Laboratory - Kurt Glaesemann
+! University of Texas at Austin - Alex Demkov
+! Ohio University - Dave Drabold
+! Washington University - Pete Fedders
+! West Virginia University - Ning Ma and Hao Wang
+! also Gary Adams, Juergen Frisch, John Tomfohr, Kevin Schmidt,
+!      and Spencer Shellman
+
+!
+! RESTRICTED RIGHTS LEGEND
+! Use, duplication, or disclosure of this software and its documentation
+! by the Government is subject to restrictions as set forth in subdivision
+! { (b) (3) (ii) } of the Rights in Technical Data and Computer Software
+! clause at 52.227-7013.
+
+! M_Fdata_1c
+! Module Description
+! ===========================================================================
+!>       This is a module containing all of the subroutines that will read in
+!! all the data from the data files in the Fdata directory.  It contains the
+!! following subroutines within the module:
+!!
+!!       read_xc1c.f90 - read in data from one-center xc McWEDA datafiles.
+!!       destroy_xc1c.f90 - destroy allocatable arrays related to the one-center
+!!                          McWeda interactions.
+!
+! ===========================================================================
+! Code written by:
+!> @author Ning Ma
+!> @author James P. Lewis\n
+!! Box 6315, 209 Hodges Hall\n
+!! Department of Physics\n
+!! West Virginia University\n
+!! Morgantown, WV 26506-6315\n
+!
+! (304) 293-3422 x1409 (office)
+! (304) 293-5732 (FAX)
+! ===========================================================================
+!
+! Module Declaration
+! ===========================================================================
+        module M_Fdata_1c
+        use M_species
+
+! Type Declaration
+! ===========================================================================
+! one-center xc data for McWEDA
+        type T_vxc_1c
+          real, pointer :: E(:,:)              !< xc-energy (shells)
+          real, pointer :: V(:, :)             !< Vxc potential
+        end type T_vxc_1c
+
+! module variables
+        type (T_vxc_1c), pointer :: vxc_1c (:) !< one-center xc for McWEDA
+
+! module procedures
+        contains
+
+! ===========================================================================
+! read_Fdata_1c
+! ===========================================================================
+! Subroutine Description
+! ===========================================================================
+!>       This routine reads in the one-center (exchange-correlation)
+!! interactions for McWEDA. These one-center interactions are contributions
+!! as described in
+!!
+!! "Multicenter approach to the exchange-correlation interactions in ab initio
+!!  tight-binding methods" by P. Jelinek, H. Wang, J.P. Lewis, O.F. Sankey,
+!!  and J. Ortega, PRB 71:23511 (2005).
+!!
+!! This routine also reads in the variables which are needed to compute
+!! changes of the exchange correlation for the charge transfer which is
+!! contained in the one-center datafiles.
+!
+! ===========================================================================
+! Code written by:
+!> @author Daniel G. Trabada
+!! @author J. Ortega
+!! @author James P. Lewis\n
+!! Box 6315, 209 Hodges Hall\n
+!! Department of Physics\n
+!! West Virginia University\n
+!! Morgantown, WV 26506-6315\n
+!
+! (304) 293-3422 x1409 (office)
+! (304) 293-5732 (FAX)
+! ===========================================================================
+!
+! Subroutine Declaration
+! ===========================================================================
+        subroutine read_Fdata_1c ()
+        implicit none
+
+! Argument Declaration and Description
+! ===========================================================================
+! None
+
+! Parameters and Data Declaration
+! ===========================================================================
+! None
+
+! Variable Declaration and Description
+! ===========================================================================
+        integer ispecies                   !< counters for number of species
+
+        integer nssh                      !< counters for number of shells
+        integer issh, jssh
+
+        character (len=32) filename
+
+! Allocate Arrays
+! ===========================================================================
+        allocate (vxc_1c (nspecies))
+
+! Procedure
+! ===========================================================================
+! ***************************************************************************
+!                 R E A D    M A T R I X    E L E M E N T S
+! ***************************************************************************
+        do ispecies = 1, nspecies
+
+          ! Open ouput file for this species pair
+          write (filename, '("/xc_1c", ".", i2.2, ".dat")')                  &
+     &  	species(ispecies)%nZ
+          open (11, file = trim(fdata_location)//trim(filename),             &
+     &          status = 'old')
+
+          nssh = species(ispecies)%nssh
+          allocate (vxc_1c(ispecies)%E(nssh,nssh))
+          allocate (vxc_1c(ispecies)%V(nssh,nssh))
+
+          ! 0th order
+          do issh = 1, nssh
+            read (11,*) (vxc_1c(ispecies)%E(issh,jssh), jssh = 1, nssh)
+          end do
+          do issh = 1, nssh
+            read (11,*) (vxc_1c(ispecies)%V(issh,jssh), jssh = 1, nssh)
+          end do
+        end do
+        close (11)
+
+
+! Deallocate Arrays
+! ===========================================================================
+! None
+
+! Format Statements
+! ===========================================================================
+! None
+
+! End Subroutine
+! ===========================================================================
+        return
+        end subroutine read_Fdata_1c
+
+
+! ===========================================================================
+! destroy_Fdata_1c
+! ===========================================================================
+! Subroutine Description
+! ===========================================================================
+!>       This routine deallocates the one-center (exchange-correlation)
+!! interactions for McWEDA - these arrays are read in by read_vxc_1c.
+!
+! ===========================================================================
+! Code written by:
+!> @author Ning Ma
+!! @author James P. Lewis\n
+!! Box 6315, 209 Hodges Hall\n
+!! Department of Physics\n
+!! West Virginia University\n
+!! Morgantown, WV 26506-6315\n
+!
+! (304) 293-3422 x1409 (office)
+! (304) 293-5732 (FAX)
+! ===========================================================================
+!
+! Subroutine Declaration
+! ===========================================================================
+        subroutine destroy_Fdata_1c ()
+        implicit none
+
+! Argument Declaration and Description
+! ===========================================================================
+! None
+
+! Parameters and Data Declaration
+! ===========================================================================
+! None
+
+! Variable Declaration and Description
+! ===========================================================================
+        integer ispecies
+
+! Procedure
+! ===========================================================================
+        do ispecies = 1, nspecies
+          deallocate (vxc_1c(ispecies)%E)
+          deallocate (vxc_1c(ispecies)%V)
+        end do
+
+! Deallocate Arrays
+! ===========================================================================
+        deallocate (vxc_1c)
+
+! Format Statements
+! ===========================================================================
+! None
+
+! End Subroutine
+! ===========================================================================
+        return
+        end subroutine destroy_Fdata_1c
+
+
+! End Module
+! ===========================================================================
+        end module M_Fdata_1c

--- a/src/h.SOLVESH/M_kspace_Lowdin.f90
+++ b/src/h.SOLVESH/M_kspace_Lowdin.f90
@@ -404,7 +404,7 @@
             norb_nu = species(in2)%norb_max
             do imu = 1, norb_mu
               write (logfile,104)                                            &
-     &         (pK_neighbors%block(imu,inu), inu = 1, norb_nu)
+     &         (pK_neighbors%blocko(imu,inu), inu = 1, norb_nu)
             end do
 
 ! Neutral atom matrix elements
@@ -496,7 +496,7 @@
             norb_nu = species(in2)%norb_max
             do imu = 1, norb_mu
               write (logfile,104)                                            &
-     &         (pSR_neighbors%block(imu,inu), inu = 1, norb_nu)
+     &         (pSR_neighbors%blocko(imu,inu), inu = 1, norb_nu)
             end do
 
 ! Long-range ewald matrix elements
@@ -509,7 +509,7 @@
             norb_nu = species(in2)%norb_max
             do imu = 1, norb_mu
               write (logfile,104)                                            &
-     &         (pLR_neighbors%block(imu,inu), inu = 1, norb_nu)
+     &         (pLR_neighbors%blocko(imu,inu), inu = 1, norb_nu)
             end do
 
 ! Complete Hamiltonian (without vnl) matrix elements
@@ -573,6 +573,8 @@
 ! Subroutine Description
 ! ===========================================================================
 !> This subroutine calculates overlap matix S in k space:
+
+
 !! s(k) = sum(l) exp(iatom*k - dot - (l + bj - bi)) s((0,iatom), (l,jatom))
 !! and diagonalizes. The eigenvalues are stores in 1D array structure:
 !! k_slam%values(:)

--- a/src/j.ASSEMBLERS/M_assemble_vxc_McWEDA_Harris.f90
+++ b/src/j.ASSEMBLERS/M_assemble_vxc_McWEDA_Harris.f90
@@ -111,7 +111,8 @@
 
 ! Variable Declaration and Description
 ! ===========================================================================
-        integer iatom, ineigh, matom       !< counter over atoms and neighbors
+!       integer iatom, ineigh, matom       !< counter over atoms and neighbors
+        integer iatom, ineigh              !< counter over atoms and neighbors
         integer in1, in2                   !< species numbers
         integer jatom                      !< neighbor of iatom
         integer logfile                    !< writing to which unit
@@ -172,23 +173,23 @@
             jatom = s%neighbors(iatom)%neigh_j(ineigh)
             in2 = s%atom(jatom)%imass
             norb_nu = species(in2)%norb_max
-            allocate (pvxc_neighbors%blocko(norb_mu, norb_nu))
-            pvxc_neighbors%blocko = 0.0d0
+            allocate (pvxc_neighbors%block(norb_mu, norb_nu))
+            pvxc_neighbors%block = 0.0d0
 
 ! equation (16) PRB 71, 235101 (2005)
 ! vxc = vxc_bond + vxc_SN - vxc_SN_bond
-            pvxc_neighbors%blocko = vxc_SN(iatom)%neighbors(ineigh)%blocko     &
-     &                             + vxc_bond(iatom)%neighbors(ineigh)%blocko  &
-     &                             - vxc_SN_bond(iatom)%neighbors(ineigh)%blocko
+            pvxc_neighbors%block = vxc_SN(iatom)%neighbors(ineigh)%block       &
+     &                             + vxc_bond(iatom)%neighbors(ineigh)%block   &
+     &                             - vxc_SN_bond(iatom)%neighbors(ineigh)%block
           end do
-          matom = s%neigh_self(iatom)
+!         matom = s%neigh_self(iatom)
                     
           ! cut some lengthy notation
-          pvxc_neighbors=>pvxc%neighbors(matom)
-          allocate (pvxc_neighbors%block(norb_mu, norb_mu))
-          pvxc_neighbors%block = 0.0d0
-          pvxc_neighbors%block = vxc_SN(iatom)%neighbors(matom)%block     &
-     &                          - vxc_SN_bond(iatom)%neighbors(matom)%block
+!         pvxc_neighbors=>pvxc%neighbors(matom)
+!         allocate (pvxc_neighbors%block(norb_mu, norb_mu))
+!         pvxc_neighbors%block = 0.0d0
+!         pvxc_neighbors%block = vxc_SN(iatom)%neighbors(matom)%block     &
+!    &                          - vxc_SN_bond(iatom)%neighbors(matom)%block
         end do
 
 ! Deallocate Arrays
@@ -370,11 +371,11 @@
                       prho_bond = s%rho_bond(iatom)%neighbors(ineigh)%block(imu,inu)
 
 ! calculate GSN for rho_in
-                      pvxc_SN_neighbors%blocko(imu,inu) = muxc_in*poverlap      &
+                      pvxc_SN_neighbors%block(imu,inu) = muxc_in*poverlap      &
      &                  + dmuxc_in*(prho_in - prho_in_shell*poverlap)
                       
 ! calculate GSN for rho_bond ("atomic" correction)
-                      pvxc_SN_bond_neighbors%blocko(imu,inu) =                 &
+                      pvxc_SN_bond_neighbors%block(imu,inu) =                  &
      &                  muxc_bond*poverlap                                     &
      &                  + dmuxc_bond*(prho_bond - prho_bond_shell*poverlap)
                     end do !do m2 = -l2, l2
@@ -446,6 +447,7 @@
               imu = n1 + m1
               prho_in = s%rho_in(iatom)%neighbors(matom)%block(imu,imu)
               prho_bond = s%rho_bond(iatom)%neighbors(matom)%block(imu,imu)
+
 ! calculate GSN for rho_in
               pvxc_SN_neighbors%block(imu,imu) = muxc_in                     &
      &          + dmuxc_in*(prho_in - prho_in_shell)
@@ -484,8 +486,8 @@
                   if (imu .ne. inu) then
                     prho_in = s%rho_in(iatom)%neighbors(matom)%block(imu,inu)
                     prho_bond = s%rho_bond(iatom)%neighbors(matom)%block(imu,inu)
+
 ! calculate GSN for rho_in
-                    
                     pvxc_SN_neighbors%block(imu,inu) = dmuxc_in*prho_in
                     pvxc_SN_bond_neighbors%block(imu,inu) = dmuxc_bond*prho_bond
                   end if ! imu .eq. inu
@@ -609,8 +611,8 @@
 
 ! Allocate block size
             norb_nu = species(in2)%norb_max
-            allocate (pvxc_bond_neighbors%blocko(norb_mu, norb_nu))
-            pvxc_bond_neighbors%blocko = 0.0d0           
+            allocate (pvxc_bond_neighbors%block(norb_mu, norb_nu))
+            pvxc_bond_neighbors%block = 0.0d0
 
 ! SET-UP STUFF
 ! ****************************************************************************
@@ -646,7 +648,7 @@
      &                .eq. species(in1)%orbital(inu)%l .and.                &
      &                species(in1)%orbital(imu)%m                           &
      &                .eq. species(in1)%orbital(inu)%m) then
-                   pvxc_bond_neighbors%blocko(imu,inu) = vxc_1c(in1)%V(issh,jssh)
+                   pvxc_bond_neighbors%block(imu,inu) = vxc_1c(in1)%V(issh,jssh)
                   end if
                 end do
               end do
@@ -664,7 +666,7 @@
               call getMEs_Fdata_2c (in1, in3, interaction, isubtype, z,      &
      &                              norb_mu, norb_nu, bcxcm)
               call rotate (in1, in3, eps, norb_mu, norb_nu, bcxcm, bcxcx)
-              pvxc_bond_neighbors%blocko = bcxcx
+              pvxc_bond_neighbors%block = bcxcx
               deallocate (bcxcm)
               deallocate (bcxcx)
             end if ! end if for r1 .eq. r2 case
@@ -727,14 +729,14 @@
 ! ===========================================================================
         do iatom = 1, s%natoms
           do ineigh = 1, s%neighbors(iatom)%neighn
-            deallocate (s%vxc(iatom)%neighbors(ineigh)%blocko)
-            deallocate (vxc_SN(iatom)%neighbors(ineigh)%blocko)
-            deallocate (vxc_SN_bond(iatom)%neighbors(ineigh)%blocko)
+            deallocate (s%vxc(iatom)%neighbors(ineigh)%block)
+            deallocate (vxc_SN(iatom)%neighbors(ineigh)%block)
+            deallocate (vxc_SN_bond(iatom)%neighbors(ineigh)%block)
           end do
-          matom = s%neigh_self(iatom)
-          deallocate (s%vxc(iatom)%neighbors(matom)%block)
-          deallocate (vxc_SN(iatom)%neighbors(matom)%block)
-          deallocate (vxc_SN_bond(iatom)%neighbors(matom)%block)          
+!         matom = s%neigh_self(iatom)
+!         deallocate (s%vxc(iatom)%neighbors(matom)%block)
+!         deallocate (vxc_SN(iatom)%neighbors(matom)%block)
+!         deallocate (vxc_SN_bond(iatom)%neighbors(matom)%block)
           deallocate (s%vxc(iatom)%neighbors)
           deallocate (vxc_SN(iatom)%neighbors)
           deallocate (vxc_SN_bond(iatom)%neighbors)

--- a/src/o.OUTPUT/writeout_xsf.f90
+++ b/src/o.OUTPUT/writeout_xsf.f90
@@ -73,7 +73,6 @@
         integer index0                      !< index point
         integer inpfile                     !< reading from which unit
         integer logfile                     !< writing to which unit
-        !real, dimension (:,:), allocatable :: ratom2g
 
 ! Allocate Arrays
 ! ===========================================================================
@@ -89,8 +88,6 @@
 ! (format of xcrysden visual code - for details see www.xcrysden.org)
         write (logfile, *) '  Write out xsf file ', xsfname
         open (unit = inpfile, file = xsfname, status = 'unknown' )
-        !allocate (ratom2g (3, t%natoms))
-
 
 ! print the list of atoms
         if (t%icluster .eq. 1) then


### PR DESCRIPTION
The M_assemble_vxc_McWEDA_Harris and M_assemble_vxc_DOGS were combined into a single file and there were some "configure" if statements in the code to delineate between the two. This was done in order for the number of subroutines to be reduced. Stupid idea because a new developer would never be able to realize that there is some hidden "directives" in the code. 