### PR TITLE
MPI Implementation

### DIFF
--- a/src/MACHINES/HKQAI
+++ b/src/MACHINES/HKQAI
@@ -11,7 +11,7 @@ ifneq (,$(findstring HKQAI,${MACHINE}))
 			OMP = -qopenmp -fpp -auto
 		endif
 		ifneq (,$(findstring TRUE,${MPI}))
-			F90 = mpiifort
+			F90 = mpiifx
 		endif
         CC = icx
         CFLAGS = -ipo

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,7 @@ include include/OPTIONS
 # the machines file below as a starting point.  
 include MACHINES/GENERIC
 include MACHINES/HKQAI
+include MACHINES/ICC
 
 ##############################################################################
 ###
@@ -51,7 +52,7 @@ GLOBAL = M_precision.o M_assemble_blocks.o M_welcome.o
 FUNCTIONS = clebsch_gordan.o clm.o factorial.o simpson.o distance.o magnitude.o smoother.o Ylm.o a_cross_b.o Depsilon_2c.o Depsilon_3c.o invert3x3.o mult3x1.o mult3x3.o Dsmoother.o
 
 # Objects from c.SYSTEM
-SYSTEM_BEGIN =  M_species.o M_atom_functions.o M_atomPP_functions_KB.o M_atomPP_ion_functions_KB.o M_integrals_2c.o
+SYSTEM_BEGIN = M_species.o M_atom_functions.o M_atomPP_functions_KB.o M_atomPP_ion_functions_KB.o M_integrals_2c.o
 SYSTEM_LOOPRC = M_species.o M_atom_functions.o M_atomPP_functions_KB.o M_integrals_2c.o
 SYSTEM_CREATE = M_species.o M_atom_functions.o M_integrals_2c.o M_integrals_3c.o M_atomPP_functions_KB.o M_atomPP_ion_functions_KB.o
 SYSTEM_LIGHTNING = M_species.o M_kpoints.o M_configuraciones.o M_atom_functions.o M_neighbors.o M_neighbors_PP.o M_rotations.o M_grid.o rotate_PP.o
@@ -77,6 +78,10 @@ XC_FUNCTIONALS = M_xc_option3_1c.o M_xc_option3_2c.o
 
 # McWEDA is default - we change later if we want to do Horsfield
 CREATE = M_overlap.o M_Goverlap.o M_kinetic.o M_Coulomb.o M_dipole_z.o M_vna_Harris.o M_vna_DOGS.o M_vnl_KB.o M_rho_2c_McWEDA_Harris.o M_rhoS_2c_McWEDA_Harris.o M_rho_3c_McWEDA_Harris.o M_rhoS_3c_McWEDA_Harris.o M_vxc_McWEDA_Harris.o M_vxc_McWEDA_DOGS.o M_bcna_Harris.o M_bcna_DOGS.o
+ifneq (,$(findstring TRUE, ${MPI}))
+CREATE = M_overlap.o M_Goverlap.o M_kinetic.o M_Coulomb.o M_dipole_z.o M_vna_Harris.o M_vna_DOGS.o M_vnl_KB.o M_rho_2c_McWEDA_Harris.o M_rhoS_2c_McWEDA_Harris.o M_rho_3c_McWEDA_Harris.o M_rhoS_3c_McWEDA_Harris.o M_vxc_McWEDA_Harris.o M_vxc_McWEDA_DOGS.o M_bcna_Harris.o M_bcna_DOGS.o
+PARALLEL = M_mpi.o
+endif
 # ****************************************************************************
 # END                     GENERICALLY COMPILED ROUTINES
 # ****************************************************************************
@@ -197,7 +202,7 @@ endif
 
 OBJECTS_LOOPRC = $(GLOBAL) $(FUNCTIONS) $(SYSTEM_BEGIN) $(XC_FUNCTIONALS) M_vxc_McWEDA_Harris.o $(BEGIN_LOOPRC)
 OBJECTS_BEGIN = $(GLOBAL) $(FUNCTIONS) $(SYSTEM_BEGIN) $(XC_FUNCTIONALS) M_vxc_McWEDA_Harris.o $(BEGIN)
-OBJECTS_CREATE = $(GLOBAL) $(FUNCTIONS) $(SYSTEM_CREATE) $(XC_FUNCTIONALS) $(PARALLEL) $(CREATE)
+OBJECTS_CREATE = $(PARALLEL) $(GLOBAL) $(FUNCTIONS) $(SYSTEM_CREATE) $(XC_FUNCTIONALS) $(CREATE)
 OBJECTS_LIGHTNING = $(GLOBAL) $(FUNCTIONS) $(SYSTEM_LIGHTNING) $(FUNCTIONS_LIGHTNING) $(FDATA) lda_ceperley_alder.o $(SOLVESH) $(ASSEMBLERS) $(SCF) $(OUTPUT) $(UTIL)
 OBJECTS_FIREBALL = $(GLOBAL) $(FUNCTIONS) $(SYSTEM) $(FUNCTIONS_LIGHTNING) $(FDATA) lda_ceperley_alder.o $(PARALLEL) $(SOLVESH) $(ASSEMBLERS) $(DASSEMBLERS) $(SCF) $(MD) $(OUTPUT) $(SOCKETS) $(UTIL)
 OBJECTS_MDET = $(GLOBAL) $(FUNCTIONS) $(SYSTEM)  $(FUNCTIONS_LIGHTNING) $(FDATA) lda_ceperley_alder.o $(SOLVESH) $(ASSEMBLERS) $(DASSEMBLERS) $(SCF) $(MD) $(NAMD) $(OUTPUT)
@@ -262,13 +267,14 @@ clean:
 	rm -f -r p.THEORY/*.o p.THEORY/*.mod p.THEORY/*.mod.*
 
 veryclean: clean
-	rm -f begin-looprc.x begin.x create.x lightning.x lightning-grid.x \
+	rm -f begin-looprc.x begin.x create.x create-MPI.x lightning.x lightning-grid.x \
 			fireball.x fireball-ase.x fireball-MDET.x 
 
 all:
 	make begin-looprc.x
 	make begin.x
 	make create.x
+	make create-MPI.x
 	make fireball.x
 	make fireball-ase.x
 	make fireball-MDET.x
@@ -669,6 +675,8 @@ create_Horsfield.o : x.DRIVERS/create_Horsfield.f90
 		$(F90) $(DEFS) -I.. -I../.. $(FFLAGS) -c $^ 
 create_McWEDA.o : x.DRIVERS/create_McWEDA.f90
 		$(F90) $(DEFS) -I.. -I../.. $(FFLAGS) -c $^ 
+create_McWEDA_MPI.o : x.DRIVERS/create_McWEDA_MPI.f90
+		$(F90) $(DEFS) -I.. -I../.. $(FFLAGS) -c $^ 		
 fireball.o : x.DRIVERS/fireball.f90
 		$(F90) $(DEFS) -I.. -I../.. $(FFLAGS) -c $^
 fireball-ase.o : x.DRIVERS/fireball-ase.f90

--- a/src/c.SYSTEM/M_atomPP_functions_KB.f90
+++ b/src/c.SYSTEM/M_atomPP_functions_KB.f90
@@ -65,7 +65,8 @@
         use M_species
         use M_atom_functions
 
-        implicit none
+! /MPI
+        use M_mpi
 
 ! Type Declaration
 ! ============================================================================
@@ -190,12 +191,17 @@
           open (unit = 88, file = trim(Fdata_location)//'/'//trim(file_in),  &
      &          status = 'old')
 
-          write (ilogfile,*)
-          write (ilogfile,*) ' *-----------------------------------------------* '
-          write (ilogfile,*) ' |               Welcome to READvPP              | '
-          write (ilogfile,*) ' |  Reading pseudo-potential files of the atom   | '
-          write (ilogfile,*) ' *-----------------------------------------------* '
-          write (ilogfile, 101) file_in
+! begin iammaster
+          if (my_proc .eq. 0) then
+            write (ilogfile,*)
+            write (ilogfile,*) ' *-----------------------------------------------* '
+            write (ilogfile,*) ' |               Welcome to READvPP              | '
+            write (ilogfile,*) ' |  Reading pseudo-potential files of the atom   | '
+            write (ilogfile,*) ' *-----------------------------------------------* '
+            write (ilogfile, 101) file_in
+
+! end iammaster
+          end if
 
 ! There are 14 message lines in each pseudopotential file
           do iline = 1, 14
@@ -213,36 +219,44 @@
           end if
           iexc = species_PP(ispecies)%iexc
 
-          write (ilogfile,*) ' We are reading in iexc from the pseudopotential file. '
-          write (ilogfile,*) ' This tells us which exchange-correlation approximation '
-          write (ilogfile,*) ' we are using. You have chosen iexc = ', iexc
-          write (ilogfile,*)
-          write (ilogfile,*) ' The available exchange-correlation options are: '
-          write (ilogfile,*) ' 1  LDA Wigner'
-          write (ilogfile,*) ' 2  LDA Hedin/Lundqvist'
-          write (ilogfile,*) ' 3  LDA Ceperley/Alder Perdew/Zunger (1980) '
-          write (ilogfile,*) ' 4  GGA Perdew/Wang (1991)'
-          write (ilogfile,*) ' 5  GGA Becke (1988) X, Perdew (1986)'
-          write (ilogfile,*) ' 6  GGA Perdew/Burke/Ernzerhof (1996)'
-          write (ilogfile,*) ' 7  LDA Zhao/Parr'
-          write (ilogfile,*) ' 8  LDA Ceperley/Alder Perdew/Wang (1991)'
-          write (ilogfile,*) ' 9  GGA Becke (1988) X, Lee/Yang/Parr (1988)'
-          write (ilogfile,*) ' 10 GGA Perdew/Wang (1991) X, Lee/Yang/Parr (1988)'
-          write (ilogfile,*) ' 11 LDA exchange only'
-          write (ilogfile,*) ' 12 GGA Becke (1988) X, Lee/Yang/Parr (1988), but '
-          write (ilogfile,*) '    with mixing of exact exchange. '
+! begin iammaster
+          if (my_proc .eq. 0) then
+            write (ilogfile,*) ' We are reading in iexc from the pseudopotential file. '
+            write (ilogfile,*) ' This tells us which exchange-correlation approximation '
+            write (ilogfile,*) ' we are using. You have chosen iexc = ', iexc
+            write (ilogfile,*)
+            write (ilogfile,*) ' The available exchange-correlation options are: '
+            write (ilogfile,*) ' 1  LDA Wigner'
+            write (ilogfile,*) ' 2  LDA Hedin/Lundqvist'
+            write (ilogfile,*) ' 3  LDA Ceperley/Alder Perdew/Zunger (1980) '
+            write (ilogfile,*) ' 4  GGA Perdew/Wang (1991)'
+            write (ilogfile,*) ' 5  GGA Becke (1988) X, Perdew (1986)'
+            write (ilogfile,*) ' 6  GGA Perdew/Burke/Ernzerhof (1996)'
+            write (ilogfile,*) ' 7  LDA Zhao/Parr'
+            write (ilogfile,*) ' 8  LDA Ceperley/Alder Perdew/Wang (1991)'
+            write (ilogfile,*) ' 9  GGA Becke (1988) X, Lee/Yang/Parr (1988)'
+            write (ilogfile,*) ' 10 GGA Perdew/Wang (1991) X, Lee/Yang/Parr (1988)'
+            write (ilogfile,*) ' 11 LDA exchange only'
+            write (ilogfile,*) ' 12 GGA Becke (1988) X, Lee/Yang/Parr (1988), but '
+            write (ilogfile,*) '    with mixing of exact exchange. '
+          end if
 
 ! Read the number of shells
           read (88,*) species(ispecies)%nssh_PP
           allocate (species(ispecies)%shell_PP(species(ispecies)%nssh_PP))
           read (88,*) (species(ispecies)%shell_PP(issh)%lssh,                &
      &                         issh = 1, species(ispecies)%nssh_PP)
-          write (ilogfile,*)
-          write (ilogfile,*) ' # of pseudopotential shells = ',              &
-     &                species(ispecies)%nssh_PP
-          write (ilogfile,*) ' The L values = ',                             &
-     &      (species(ispecies)%shell_PP(issh)%lssh,                          &
-     &                                  issh = 1, species(ispecies)%nssh_PP)
+! begin iammaster
+          if (my_proc .eq. 0) then
+            write (ilogfile,*)
+            write (ilogfile,*) ' # of pseudopotential shells = ',            &
+     &                         species(ispecies)%nssh_PP
+            write (ilogfile,*) ' The L values = ',                           &
+     &        (species(ispecies)%shell_PP(issh)%lssh,                        &
+     &                                    issh = 1, species(ispecies)%nssh_PP)
+
+! end iammaster
+          end if
 
 ! allocate shells
           allocate (species_PP(ispecies)%shell_PP(species(ispecies)%nssh_PP))
@@ -258,7 +272,7 @@
           read (88,*) species(ispecies)%rcutoff_PP
 
 ! Read in the short-range local part  - this is not needed for the crtor
-          write (ilogfile,*) ' Reading short-range part of pseudopotential '
+          if (my_proc .eq. 0) write (ilogfile,*) ' Reading short-range part of pseudopotential '
           read (88,*) mesh
           species_PP(ispecies)%mesh_PP = mesh
           allocate (species_PP(ispecies)%r_short(mesh))
@@ -272,7 +286,7 @@
           species_PP(ispecies)%dr_min = species_PP(ispecies)%rcutoffA_max/real(mesh - 1)
 
 ! Read in the pseudopotential - this is not needed for the crtor
-          write (ilogfile,*) ' Reading non-local part of pseudopotential '
+          if (my_proc .eq. 0) write (ilogfile,*) ' Reading non-local part of pseudopotential '
           do issh = 1, species(ispecies)%nssh_PP
             read (88,201) mesh
             species_PP(ispecies)%shell_PP(issh)%mesh_NL = mesh
@@ -296,7 +310,7 @@
      &          status = 'unknown')
 
 ! Now read in the points for the non-local part
-          write (ilogfile,*) ' Reading pseudopotential '
+          if (my_proc .eq. 0) write (ilogfile,*) ' Reading pseudopotential '
           do issh = 1, species(ispecies)%nssh_PP
             read (88,202) mesh, species(ispecies)%shell_PP(issh)%cl
             write (87,*) species(ispecies)%shell_PP(issh)%cl
@@ -329,9 +343,15 @@
             write (ilogfile,*) ' has not been implemented into CREATE yet. '
             write (ilogfile,*) ' Choose a different one, and restart. '
           end if
-          write (ilogfile,*)
-          write (ilogfile,*) ' *---------------- END READvPP -------------------*'
-          write (ilogfile,*)
+
+! begin iammaster
+          if (my_proc .eq. 0) then
+            write (ilogfile,*)
+            write (ilogfile,*) ' *---------------- END READvPP -------------------*'
+            write (ilogfile,*)
+
+! end iammaster
+          end if
         end do ! ispecies
 
 ! Deallocate Arrays

--- a/src/c.SYSTEM/M_integrals_2c.f90
+++ b/src/c.SYSTEM/M_integrals_2c.f90
@@ -65,6 +65,9 @@
        use M_atom_functions
        use M_species
 
+! /MPI
+       use M_MPI
+
        include '../include/interactions_2c.h'
 
 ! Type Declaration
@@ -163,14 +166,17 @@
 
 ! Procedure
 ! ===========================================================================
-        write (ilogfile, *)
-        write (ilogfile, *) ' Sizing two-center integrals: '
+        if (my_proc .eq. 0) write (ilogfile, *)
+        if (my_proc .eq. 0) write (ilogfile, *) ' Sizing two-center integrals: '
         do ispecies = 1, nspecies
           do jspecies = 1, nspecies
 
             ! cut some lengthy notation
             pFdata_bundle=>Fdata_bundle_2c(ispecies, jspecies)
-            write (ilogfile,100) ispecies, jspecies, pFdata_bundle%nFdata_cell_2c
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,100) ispecies, jspecies, pFdata_bundle%nFdata_cell_2c
+            end if
             allocate (pFdata_bundle%Fdata_cell_2c(pFdata_bundle%nFdata_cell_2c))
 
 ! Set this back to zero and then start counting as interactions are computed.

--- a/src/c.SYSTEM/M_integrals_3c.f90
+++ b/src/c.SYSTEM/M_integrals_3c.f90
@@ -153,14 +153,28 @@
 
 ! Procedure
 ! ===========================================================================
-        write (ilogfile, *)
-        write (ilogfile, *) ' Sizing three-center integrals: '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile, *)
+          write (ilogfile, *) ' Sizing three-center integrals: '
+
+! end iammaster
+        end if
+
         do ispecies = 1, nspecies
           do jspecies = 1, nspecies
             do kspecies = 1, nspecies
               ! cut some lengthy notation
               pFdata_bundle=>Fdata_bundle_3c(ispecies, jspecies, kspecies)
-              write (ilogfile,100) ispecies, jspecies, kspecies, pFdata_bundle%nFdata_cell_3c
+
+! begin iammaster
+              if (my_proc .eq. 0) then
+                write (ilogfile,100) ispecies, jspecies, kspecies,           &
+     &                               pFdata_bundle%nFdata_cell_3c
+
+! end iammaster
+              end if
+
               allocate (pFdata_bundle%Fdata_cell_3c(pFdata_bundle%nFdata_cell_3c))
 
 ! Set this back to zero and then start counting as interactions are computed.

--- a/src/c.SYSTEM/M_species.f90
+++ b/src/c.SYSTEM/M_species.f90
@@ -61,8 +61,11 @@
 ! ===========================================================================
         module M_species
 
+! /GLOBAL
         use M_precision
-        implicit none
+
+! /MPI
+        use M_mpi
 
 ! Type Declaration
 ! ===========================================================================
@@ -216,7 +219,7 @@
 ! Procedure
 ! ===========================================================================
 ! Read in the species file.
-        write (ilogfile,*) ' Reading: Fdata.inp  '
+        if (my_proc .eq. 0) write (ilogfile,*) ' Reading: Fdata.inp  '
         inquire(file = "Fdata.inp", exist = file_exists)   ! file_exists will be TRUE if the file
                                                            ! exists and FALSE otherwise
         if ( file_exists ) then
@@ -233,7 +236,7 @@
         end do
 
         read (11,*) Fdata_location
-        write (ilogfile,101) Fdata_location
+        if (my_proc .eq. 0) write (ilogfile,101) Fdata_location
         close (11)
 
 ! Deallocate Arrays
@@ -791,8 +794,14 @@
 ! ===========================================================================
 ! We now read in a create.input file. This determines the number of atoms
 ! and the types of atoms.
-        write (ilogfile,*) '  '
-        write (ilogfile,*) ' We now read create.inp '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' We now read create.inp '
+
+! end iammaster
+        end if
+
         open (unit = 11, file = 'create.inp', status = 'old')
         read (11, 101) signature
 
@@ -825,8 +834,15 @@
 ! Check whether you put in the correct nz for that atom.
 ! Go through the periodic table and check.
           atomcheck = periodic(species(ispecies)%nZ)
-          write (ilogfile,201) ispecies, species(ispecies)%nZ,               &
-     &                 species(ispecies)%symbol, atomcheck
+
+! begin iammaster
+          if (my_proc .eq. 0) then
+            write (ilogfile,201) ispecies, species(ispecies)%nZ,             &
+     &                                     species(ispecies)%symbol, atomcheck
+
+! end iammaster
+          end if
+
           if (species(ispecies)%symbol .ne. atomcheck) stop                  &
      &      ' wrong nz(nuc) for atom!!'
 

--- a/src/f.MPI/M_mpi.f90
+++ b/src/f.MPI/M_mpi.f90
@@ -52,11 +52,9 @@
 
 ! Variable Declaration and Description
 ! ===========================================================================
+        integer ierr_mpi
         integer my_proc
-        integer nprocessors
-
-        logical iammaster
-        logical iammpi
+        integer nprocs
 
 ! module procedures
         contains
@@ -87,8 +85,7 @@
 
 ! Argument Declaration and Description
 ! ===========================================================================
-! Output
-
+! None
 
 ! Local Parameters and Data Declaration
 ! ===========================================================================
@@ -105,19 +102,18 @@
           write(*,*) 'mpi error MPI_Init'
           stop
         end if
+
         call MPI_COMM_RANK (MPI_COMM_WORLD, my_proc, ierr_mpi)
         if (ierr_mpi .ne. 0) then
           write (*,*) ' mpi error MPI_COMM_RANK'
           stop
         end if
-        call MPI_COMM_SIZE (MPI_COMM_WORLD, nprocessors, ierr_mpi)
+
+        call MPI_COMM_SIZE (MPI_COMM_WORLD, nprocs, ierr_mpi)
         if (ierr_mpi .ne. 0) then
           write (*,*) 'mpi error MPI_COMM_SIZE'
           stop
         end if
-        iammaster = .false.
-        if (my_proc .eq. 0) iammaster = .true.
-        iammpi = .true.
 
 ! Format Statements
 ! ===========================================================================

--- a/src/f.MPI/M_nompi.f90
+++ b/src/f.MPI/M_nompi.f90
@@ -52,10 +52,7 @@
 ! Variable Declaration and Description
 ! ===========================================================================
         integer my_proc
-        integer nprocessors
-
-        logical iammaster
-        logical iammpi
+        integer nprocs
 
 ! module procedures
         contains
@@ -88,9 +85,7 @@
 ! Procedure
 ! ===========================================================================
         my_proc = 0
-        nprocessors = 1
-        iammaster = .true.
-        iammpi = .false.
+        nprocs = 1
 
 ! Format Statements
 ! ===========================================================================

--- a/src/p.THEORY/M_Coulomb.f90
+++ b/src/p.THEORY/M_Coulomb.f90
@@ -58,7 +58,8 @@
         use M_atom_functions
         use M_integrals_2c
 
-        implicit none
+! /MPI
+        use M_MPI
 
 ! Type Declaration
 ! ============================================================================
@@ -202,10 +203,13 @@
 
 ! Procedure
 ! ============================================================================
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '          C O U L O M B   I N T E R A C T I O N S        '
-        write (ilogfile,*) ' ******************************************************* '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '          C O U L O M B   I N T E R A C T I O N S        '
+          write (ilogfile,*) ' ******************************************************* '
+        end if
 
 ! Assign values to the unrequired variables for this specific interaction.
         isorp = 0
@@ -225,6 +229,11 @@
             call make_munuS (nFdata_cell_2c, ispecies, jspecies)
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
+
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
+            end if
 
             ! Open ouput file for this species pair
             write (filename, '("/coulomb",".",i2.2,".",i2.2,".dat")')        &
@@ -266,9 +275,9 @@
             write (12,*) (pFdata_cell%nu_2c(index_2c), index_2c = 1, nME2c_max)
             write (12,*) (pFdata_cell%mvalue_2c(index_2c),                   &
      &                     index_2c = 1, nME2c_max)
+            close (unit = 12)
 
 ! Loop over grid
-            write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_coulomb
               d = d + drr
               call evaluate_integral_2c (nFdata_cell_2c, ispecies, jspecies,&

--- a/src/p.THEORY/M_dipole_z.f90
+++ b/src/p.THEORY/M_dipole_z.f90
@@ -59,6 +59,9 @@
         use M_species
         use M_integrals_2c
 
+! /MPI
+        use M_MPI
+
 ! Type Declaration
 ! ============================================================================
 ! None
@@ -194,10 +197,14 @@
 
 ! Procedure
 ! ============================================================================
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '        D I P O L E ( Z )   I N T E R A C T I O N S      '
-        write (ilogfile,*) ' ******************************************************* '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '        D I P O L E ( Z )   I N T E R A C T I O N S      '
+          write (ilogfile,*) ' ******************************************************* '
+! end iammaster
+        end if
 
 ! Assign values to the unrequired variables for this specific interaction.
         isorp = 0
@@ -214,6 +221,11 @@
             call make_munu (nFdata_cell_2c, ispecies, jspecies)
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
+
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
+            end if
 
             ! Open ouput file for this species pair
             write (filename, '("/dipole_z.",i2.2,".",i2.2,".dat")')          &
@@ -254,9 +266,9 @@
             write (12,*) (pFdata_cell%nu_2c(index_2c), index_2c = 1, nME2c_max)
             write (12,*) (pFdata_cell%mvalue_2c(index_2c),                   &
      &                    index_2c = 1, nME2c_max)
+            close (unit = 12)
 
 ! Loop over grid
-            write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_dipole_z
               d = d + drr
 

--- a/src/p.THEORY/M_kinetic.f90
+++ b/src/p.THEORY/M_kinetic.f90
@@ -344,10 +344,14 @@
 !
 ! C A L C U L A T E   K I N E T I C   E N E R G Y
 ! ***************************************************************************
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '          K I N E T I C   I N T E R A C T I O N S        '
-        write (ilogfile,*) ' ******************************************************* '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '          K I N E T I C   I N T E R A C T I O N S        '
+          write (ilogfile,*) ' ******************************************************* '
+! end iammaster
+        end if
 
 ! We are ready to go
         do ispecies = 1, nspecies
@@ -361,6 +365,11 @@
             call make_munu (nFdata_cell_2c, ispecies, jspecies)
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
+
+!begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
+            end if
 
             ! Open ouput file for this species pair
             write (filename, '("/kinetic.",i2.2,".",i2.2,".dat")')           &
@@ -414,7 +423,6 @@
 ! Some preliminaries. Set up simpson rule factors and eV.
 ! Do a convergence test for d = 0.0
 ! ***************************************************************************
-            write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
             dr = (wf(ispecies)%rcutoffA_max                                  &
      &            + wf(jspecies)%rcutoffA_max)/real(ndd_ke - 1)
             dmax = (wf(ispecies)%rcutoffA_max + wf(jspecies)%rcutoffA_max)
@@ -439,7 +447,8 @@
             write (12,*) (pFdata_cell%mu_2c(index_2c), index_2c = 1, nME2c_max)
             write (12,*) (pFdata_cell%nu_2c(index_2c), index_2c = 1, nME2c_max)
             write (12,*) (pFdata_cell%mvalue_2c(index_2c),                   &
-     &                    index_2c = 1, nME2c_max)
+     &                                          index_2c = 1, nME2c_max)
+            close (unit = 12)
 
             do idgrid = 1, ndd_ke
               d = d + dr

--- a/src/p.THEORY/M_rho_3c_McWEDA_Harris.f90
+++ b/src/p.THEORY/M_rho_3c_McWEDA_Harris.f90
@@ -40,6 +40,9 @@
         use M_atom_functions
         use M_integrals_3c
 
+! /MPI
+        use M_MPI
+
 ! Type Declaration
 ! ============================================================================
 ! three-center interactions arrays
@@ -186,12 +189,15 @@
 
 ! Procedure
 ! ===========================================================================
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '               D E N S I T Y    M A T R I X              '
-        write (ilogfile,*) '                  I N T E R A C T I O N S                '
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*)
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '               D E N S I T Y    M A T R I X              '
+          write (ilogfile,*) '                  I N T E R A C T I O N S                '
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*)
+        end if
 
 ! Initialize the Legendre coefficients
         call gleg (ctheta, ctheta_weights, P_ntheta)
@@ -214,16 +220,6 @@
               allocate (qpl (P_ntheta, nME3c_max, ispmin:(ispmax - ispmin + 1)))
               qpl = 0.0d0
 
-              ! Test ouput file for this species triplet
-              itheta = 1
-              isorp = 1
-              write (filename, '("/", "rho_3c_", i2.2, "_", i2.2, ".", i2.2,  &
-     &                                       ".", i2.2, ".", i2.2, ".dat")')  &
-     &          itheta, isorp, species(ispecies)%nZ,                          &
-     &                         species(jspecies)%nZ, species(kspecies)%nZ
-              inquire (file = trim(Fdata_location)//trim(filename), exist = skip)
-              if (skip) cycle
-
               ! Set up grid loop control constants
               rcutoff1 = species(ispecies)%rcutoffA_max
               rcutoff2 = species(jspecies)%rcutoffA_max
@@ -235,45 +231,72 @@
               do isorp = ispmin, ispmax
                 do itheta = 1, P_ntheta
                   pFdata_bundle%nFdata_cell_3c = pFdata_bundle%nFdata_cell_3c + 1
-
-                  write (filename, '("/", "rho_3c_", i2.2, "_", i2.2, ".",    &
-     &                               i2.2, ".", i2.2, ".", i2.2, ".dat")')    &
-     &              itheta, isorp, species(ispecies)%nZ,                      &
-     &                             species(jspecies)%nZ, species(kspecies)%nZ
-
-                  ! open directory file
-                  write (interactions,                                        &
-     &                   '("/3c.",i2.2,".",i2.2,".",i2.2,".dir")')            &
-     &              species(ispecies)%nZ, species(jspecies)%nZ,               &
-     &              species(kspecies)%nZ
-                  open (unit = 13,                                            &
-     &                  file = trim(Fdata_location)//trim(interactions),      &
-     &                  status = 'unknown', position = 'append')
-                  write (13,100) pFdata_bundle%nFdata_cell_3c, P_rho_3c,      &
-     &                           isorp, itheta, filename(2:30),               &
-     &                           pFdata_cell%nME, nna_rho, dna, nbc_rho, dbc
-                  close (unit = 13)
-
-                  ! Open mu, nu, mvalue file and write out values.
-                  write (filename, '("/",i2.2, "_munu_3c.",                   &
-     &                                   i2.2,".",i2.2,".",i2.2,".dat")')     &
-     &              P_rho_3c, species(ispecies)%nZ, species(jspecies)%nZ,     &
-     &                        species(kspecies)%nZ
-                  open (unit = 12, file = trim(Fdata_location)//trim(filename),&
-     &                  status = 'unknown', position = 'append')
-
-                  ! Write out the mapping - stored in mu, nu, and mvalue
-                  write (12,*) (pFdata_cell%mu_3c(index_3c),                  &
-     &                                            index_3c = 1, nME3c_max)
-                  write (12,*) (pFdata_cell%nu_3c(index_3c),                  &
-     &                                            index_3c = 1, nME3c_max)
-                  write (12,*) (pFdata_cell%mvalue_3c(index_3c),              &
-     &                                                index_3c = 1, nME3c_max)
                 end do
               end do
 
-              write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ,&
-     &                             species(kspecies)%nZ
+! begin iammaster
+              if (my_proc .eq. 0) then
+                write (ilogfile,200) species(ispecies)%nZ,                   &
+     &                               species(jspecies)%nZ, species(kspecies)%nZ
+                do isorp = ispmin, ispmax
+                 do itheta = 1, P_ntheta
+                   pFdata_bundle%nFdata_cell_3c = pFdata_bundle%nFdata_cell_3c - 1
+                 end do
+                end do
+
+                do isorp = ispmin, ispmax
+                  do itheta = 1, P_ntheta
+                    pFdata_bundle%nFdata_cell_3c = pFdata_bundle%nFdata_cell_3c + 1
+                    write (filename, '("/", "rho_3c_", i2.2, "_", i2.2, ".",  &
+     &                                 i2.2, ".", i2.2, ".", i2.2, ".dat")')  &
+     &                itheta, isorp, species(ispecies)%nZ,                    &
+     &                               species(jspecies)%nZ, species(kspecies)%nZ
+
+                    ! open directory file
+                    write (interactions,                                      &
+     &                     '("/3c.",i2.2,".",i2.2,".",i2.2,".dir")')          &
+     &                species(ispecies)%nZ, species(jspecies)%nZ,             &
+     &                species(kspecies)%nZ
+                    open (unit = 13,                                          &
+     &                    file = trim(Fdata_location)//trim(interactions),    &
+     &                    status = 'unknown', position = 'append')
+                    write (13,100) pFdata_bundle%nFdata_cell_3c, P_rho_3c,    &
+     &                             isorp, itheta, filename(2:30),             &
+     &                             pFdata_cell%nME, nna_rho, dna, nbc_rho, dbc
+                    close (unit = 13)
+
+                    ! Open mu, nu, mvalue file and write out values.
+                    write (filename, '("/",i2.2, "_munu_3c.",                 &
+     &                                     i2.2,".",i2.2,".",i2.2,".dat")')   &
+     &                P_rho_3c, species(ispecies)%nZ, species(jspecies)%nZ,   &
+     &                          species(kspecies)%nZ
+                    open (unit = 12,                                          &
+     &                    file = trim(Fdata_location)//trim(filename),        &
+     &                    status = 'unknown', position = 'append')
+
+                    ! Write out the mapping - stored in mu, nu, and mvalue
+                    write (12,*) (pFdata_cell%mu_3c(index_3c),                &
+     &                                              index_3c = 1, nME3c_max)
+                    write (12,*) (pFdata_cell%nu_3c(index_3c),                &
+     &                                              index_3c = 1, nME3c_max)
+                    write (12,*) (pFdata_cell%mvalue_3c(index_3c),            &
+     &                                                  index_3c = 1, nME3c_max)
+                    close (unit = 12)
+                  end do
+                end do
+
+! end iammaster
+              end if
+
+              ! Test ouput file for this species triplet
+              itheta = 1
+              isorp = 1
+              write (filename, '("/", "rho_3c_", i2.2, "_", i2.2, ".", i2.2,  &
+     &                                       ".", i2.2, ".", i2.2, ".dat")')  &
+     &          itheta, isorp, species(ispecies)%nZ,                          &
+     &                         species(jspecies)%nZ, species(kspecies)%nZ
+              inquire (file = trim(Fdata_location)//trim(filename), exist = skip)
+              if (skip) cycle
 
 ! Open all the output files.
               iounit = 12

--- a/src/p.THEORY/M_vnl_KB.f90
+++ b/src/p.THEORY/M_vnl_KB.f90
@@ -56,7 +56,8 @@
         use M_atomPP_functions
         use M_integrals_2c
 
-        implicit none
+! /MPI
+        use M_MPI
 
 ! Type Declaration
 ! ============================================================================
@@ -217,10 +218,14 @@
 
 ! Procedure
 ! ============================================================================
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '              P P   I N T E R A C T I O N S              '
-        write (ilogfile,*) ' ******************************************************* '
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '              P P   I N T E R A C T I O N S              '
+          write (ilogfile,*) ' ******************************************************* '
+! end iammaster
+        end if
 
 ! Assign values to the unrequired variables for this specific interaction.
         isorp = 0
@@ -237,6 +242,11 @@
             call make_munu_PP (nFdata_cell_2c, ispecies, jspecies)
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
+
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
+            end if
 
             ! Open ouput file for this species pair
             write (filename, '("/vnl.",i2.2,".",i2.2,".dat")')               &
@@ -262,7 +272,7 @@
      &        species(ispecies)%nZ, species(jspecies)%nZ
             open (unit = 13, file = trim(Fdata_location)//trim(interactions),&
      &            status = 'unknown', position = 'append')
-            write (13,100) pFdata_bundle%nFdata_cell_2c, P_vnl, isorp,   &
+            write (13,100) pFdata_bundle%nFdata_cell_2c, P_vnl, isorp,       &
      &                     filename(2:30), pFdata_cell%nME, ndd_vnl, dmax
             close (unit = 13)
 
@@ -278,7 +288,6 @@
             write (12,*) (pFdata_cell%mvalue_2c(index_2c), index_2c = 1, nME2c_max)
 
 ! Loop over grid
-            write (ilogfile,200) species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_vnl
               d = d + drr
 

--- a/src/p.THEORY/M_vxc_Horsfield_Harris.f90
+++ b/src/p.THEORY/M_vxc_Horsfield_Harris.f90
@@ -64,6 +64,9 @@
         use M_xc_1c
         use M_xc_2c
 
+! /MPI
+        use M_MPI
+
 ! Type Declaration
 ! ===========================================================================
 ! This type contains the two-center density and derivatives on rho, z grid
@@ -204,12 +207,15 @@
 
 ! Procedure
 ! ===========================================================================
-        write (ilogfile,*)
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*) '        E X C H A N G E   C O R R E L A T I O N          '
-        write (ilogfile,*) '                  I N T E R A C T I O N S                '
-        write (ilogfile,*) ' ******************************************************* '
-        write (ilogfile,*)
+! begin iammaster
+        if (my_proc .eq. 0) then
+          write (ilogfile,*)
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*) '        E X C H A N G E   C O R R E L A T I O N          '
+          write (ilogfile,*) '                  I N T E R A C T I O N S                '
+          write (ilogfile,*) ' ******************************************************* '
+          write (ilogfile,*)
+        end if
 
 ! We are doing Harris interactions here, so we set Qneutral_ion to the
 ! non-charged atom before calculating the densities.  The Qneutral is used
@@ -222,11 +228,15 @@
          end do
         end do
 
-        write (ilogfile,*) ' Calling one-center case. '
+        if (my_proc .eq. 0) write (ilogfile,*) ' Calling one-center case. '
         call vxc_1c_Harris
 
-        write (ilogfile,*)
-        write (ilogfile,*) ' Building the two center density on grid '
+! begin iammaster
+        if (my_proc .eq. 0) write (ilogfile,*)
+        if (my_proc .eq. 0) then
+          write (ilogfile,*) ' Building the two center density on grid '
+        end if
+
         allocate (rho_2c_bundle (nspecies, nspecies))
         do ispecies = 1, nspecies
           do jspecies = 1, nspecies
@@ -234,16 +244,16 @@
           end do
         end do
 
-        write (ilogfile,*)
-        write (ilogfile,*) ' Calling correction case. '
+        if (my_proc .eq. 0) write (ilogfile,*)
+        if (my_proc .eq. 0) write (ilogfile,*) ' Calling correction case. '
         call uxc_Harris
 
-        write (ilogfile,*)
-        write (ilogfile,*) ' Calling ontop case. '
+        if (my_proc .eq. 0) write (ilogfile,*)
+        if (my_proc .eq. 0) write (ilogfile,*) ' Calling ontop case. '
         call vxc_ontop_Harris
 
-        write (ilogfile,*)
-        write (ilogfile,*) ' Calling atom case. '
+        if (my_proc .eq. 0) write (ilogfile,*)
+        if (my_proc .eq. 0) write (ilogfile,*) ' Calling atom case. '
         call vxc_atom_Harris
 
 ! Deallocate Arrays
@@ -493,7 +503,7 @@
           rhomax = species(ispecies)%rcutoffA_max
 
 ! Loop over grid
-          write (ilogfile,100) species(ispecies)%nZ
+          if (my_proc .eq. 0) write (ilogfile,100) species(ispecies)%nZ
 
 ! ***************************************************************************
 ! exc_1c piece:
@@ -1212,6 +1222,11 @@
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
 
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
+            end if
+
             ! Open ouput file for this species pair
             write (filename, '("/uxc_", i2.2,".",i2.2,".",i2.2,".dat")') &
      &             ideriv, species(ispecies)%nZ, species(jspecies)%nZ
@@ -1252,7 +1267,6 @@
      &                    index_2c = 1, nME2c_max)
 
 ! Loop over grid
-            write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_uxc
               d = d + drr
 
@@ -1672,6 +1686,11 @@
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
 
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
+            end if
+
             ! Open ouput file for this species pair
             write (filename, '("/vxc_ontop_", i2.2,".",i2.2,".",i2.2,".dat")')&
      &  	       ideriv, species(ispecies)%nZ, species(jspecies)%nZ
@@ -1713,7 +1732,6 @@
      &                    index_2c = 1, nME2c_max)
 
 ! Loop over grid
-            write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_vxc
               d = d + drr
 
@@ -2106,6 +2124,11 @@
             nME2c_max = pFdata_cell%nME
             allocate (pFdata_cell%fofx(nME2c_max))
 
+! begin iammaster
+            if (my_proc .eq. 0) then
+              write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
+            end if
+
             ! Open ouput file for this species pair
             write (filename, '("/vxc_atom_", i2.2,".",i2.2,".",i2.2,".dat")') &
      &             ideriv, species(ispecies)%nZ, species(jspecies)%nZ
@@ -2146,7 +2169,6 @@
      &                    index_2c = 1, nME2c_max)
 
 ! Loop over grid
-            write (ilogfile,200) ideriv, species(ispecies)%nZ, species(jspecies)%nZ
             do igrid = 1, ndd_vxc
               d = d + drr
 


### PR DESCRIPTION
 Serial and parallel code use the same routines - added statements for should be run on my_proc = 0.  Use a clever trick that will use "skip" logical if the file is already begin calculated by another processor. Therefore, foregoing the use of MPI or the superloop construct that was utilized in the previous 2000 version of create.x